### PR TITLE
Reset scroll spy flag when disabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -10285,6 +10285,7 @@
                 // 🔍 DEBUG: Verificar se scroll spy está habilitado
                 if (!scrollSpyEnabled) {
                     debugLog('🚫 updateScrollSpy: BLOQUEADO (scrollSpyEnabled = false)');
+                    ticking = false;
                     return;
                 }
                 


### PR DESCRIPTION
## Summary
- reset `ticking` flag when scroll spy is disabled to avoid stale throttle state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ec99b9ae483209dbee5a9ef3b9293